### PR TITLE
Rename project to labels2env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL = /bin/bash
 .PHONY: test test-ci
 
 test:
-    coverage run --source=./src -m pytest labels2env/tests.py
+    coverage run --source=./labels2env -m pytest labels2env/tests.py
     coverage html
 
 test-ci: test

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL = /bin/bash
 .PHONY: test test-ci
 
 test:
-    coverage run --source=./src -m pytest src/tests/
+    coverage run --source=./src -m pytest labels2env/tests.py
     coverage html
 
 test-ci: test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyGithub==1.43.8
 PyInstaller==3.5
 pytest==5.0.1
+coverage==4.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyGithub==1.43.8
 PyInstaller==3.5
 pytest==5.0.1
 coverage==4.5.3
+codecov==2.0.15


### PR DESCRIPTION
The project is now called `labels2env`. 

The main objective is to simplify the name.

From now on, CI/CD is activated as well.